### PR TITLE
feat: Extend Flutter Bridge with full platform support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -226,61 +226,60 @@ class _WebViewPageState extends State<WebViewPage> {
     return Scaffold(
       body: Stack(
         children: [
-            PopScope(
-              canPop: false,
-              onPopInvokedWithResult: (didPop, result) async {
-                if (didPop) return;
-                if (await _controller.canGoBack()) {
-                  await _controller.goBack();
-                } else {
-                  // 더 이상 뒤로 갈 수 없으면 앱 종료 (기본 동작 수행을 위해 canPop을 활용하거나 직접 종료 제어 가능)
-                  if (context.mounted) {
-                    SystemNavigator.pop();
-                  }
+          PopScope(
+            canPop: false,
+            onPopInvokedWithResult: (didPop, result) async {
+              if (didPop) return;
+              if (await _controller.canGoBack()) {
+                await _controller.goBack();
+              } else {
+                // 더 이상 뒤로 갈 수 없으면 앱 종료 (기본 동작 수행을 위해 canPop을 활용하거나 직접 종료 제어 가능)
+                if (context.mounted) {
+                  SystemNavigator.pop();
                 }
-              },
-              child: WebViewWidget(controller: _controller),
-            ),
-            if (_isLoading) const Center(child: CircularProgressIndicator()),
-            if (_errorMessage != null)
-              Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Icon(
-                        Icons.error_outline,
-                        size: 48,
-                        color: Colors.red,
-                      ),
-                      const SizedBox(height: 16),
-                      Text(
-                        'Error loading page',
-                        style: Theme.of(context).textTheme.titleLarge,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        _errorMessage!,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                        onPressed: () {
-                          setState(() {
-                            _errorMessage = null;
-                          });
-                          _controller.reload();
-                        },
-                        child: const Text('Retry'),
-                      ),
-                    ],
-                  ),
+              }
+            },
+            child: WebViewWidget(controller: _controller),
+          ),
+          if (_isLoading) const Center(child: CircularProgressIndicator()),
+          if (_errorMessage != null)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: Colors.red,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Error loading page',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      _errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          _errorMessage = null;
+                        });
+                        _controller.reload();
+                      },
+                      child: const Text('Retry'),
+                    ),
+                  ],
                 ),
               ),
-          ],
-        ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -185,14 +185,16 @@ class _WebViewPageState extends State<WebViewPage> {
           },
         ),
       )
-      ..loadRequest(Uri.parse(
-        kDebugMode
-            // Android Emulator: 10.0.2.2 = localhost
-            // iOS Simulator: localhost or 127.0.0.1
-            // Real Device: Use your machine's IP (e.g., 192.168.x.x)
-            ? 'http://10.0.2.2:5173/'
-            : 'https://tailbound.vercel.app',
-      ));
+      ..loadRequest(
+        Uri.parse(
+          kDebugMode
+              // Android Emulator: 10.0.2.2 = localhost
+              // iOS Simulator: localhost or 127.0.0.1
+              // Real Device: Use your machine's IP (e.g., 192.168.x.x)
+              ? 'http://10.0.2.2:5173/'
+              : 'https://tailbound.vercel.app',
+        ),
+      );
 
     // Android용 WebGL 및 하드웨어 가속 설정
     if (_controller.platform is AndroidWebViewController) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -186,8 +186,11 @@ class _WebViewPageState extends State<WebViewPage> {
       )
       ..loadRequest(Uri.parse(
         kDebugMode
-            ? 'http://192.168.45.39:5173/' // 로컬 개발 서버
-            : 'https://tailbound.vercel.app', // 프로덕션
+            // Android Emulator: 10.0.2.2 = localhost
+            // iOS Simulator: localhost or 127.0.0.1
+            // Real Device: Use your machine's IP (e.g., 192.168.x.x)
+            ? 'http://10.0.2.2:5173/'
+            : 'https://tailbound.vercel.app',
       ));
 
     // Android용 WebGL 및 하드웨어 가속 설정

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:webview_flutter/webview_flutter.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -224,9 +224,8 @@ class _WebViewPageState extends State<WebViewPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Stack(
-          children: [
+      body: Stack(
+        children: [
             PopScope(
               canPop: false,
               onPopInvokedWithResult: (didPop, result) async {

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -231,9 +231,13 @@ class BridgeService {
   Future<void> _pauseGame() async {
     try {
       await webViewController.runJavaScript('''
-        if (window.__PIXI_APP__ && window.__PIXI_APP__.ticker) {
-          window.__PIXI_APP__.ticker.stop();
+        if (window.__GAME_PAUSE__) {
+          window.__GAME_PAUSE__();
           console.log('[Flutter] Game paused for ad');
+        } else if (window.__PIXI_APP__ && window.__PIXI_APP__.ticker) {
+          // Fallback: ticker만 멈춤
+          window.__PIXI_APP__.ticker.stop();
+          console.log('[Flutter] Game paused (fallback) for ad');
         }
       ''');
     } catch (e) {
@@ -245,9 +249,13 @@ class BridgeService {
   Future<void> _resumeGame() async {
     try {
       await webViewController.runJavaScript('''
-        if (window.__PIXI_APP__ && window.__PIXI_APP__.ticker) {
-          window.__PIXI_APP__.ticker.start();
+        if (window.__GAME_RESUME__) {
+          window.__GAME_RESUME__();
           console.log('[Flutter] Game resumed after ad');
+        } else if (window.__PIXI_APP__ && window.__PIXI_APP__.ticker) {
+          // Fallback: ticker만 재개
+          window.__PIXI_APP__.ticker.start();
+          console.log('[Flutter] Game resumed (fallback) after ad');
         }
       ''');
     } catch (e) {

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -89,6 +89,9 @@ class BridgeService {
       case 'reroll':
         adType = RewardAdType.reroll;
         break;
+      case 'bundle':
+        adType = RewardAdType.bundle;
+        break;
       default:
         throw Exception('Unknown ad type: $adTypeStr');
     }
@@ -114,6 +117,7 @@ class BridgeService {
       },
     );
 
+    debugPrint('[Bridge] Ad result: success=$success, rewarded=$rewarded');
     return {'success': success, 'rewarded': rewarded};
   }
 

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -45,6 +45,18 @@ class BridgeService {
           case 'share.open':
             result = await _shareContent(payload);
             break;
+          case 'analytics.click':
+            result = await _handleAnalyticsClick(payload);
+            break;
+          case 'analytics.impression':
+            result = await _handleAnalyticsImpression(payload);
+            break;
+          case 'gameCenter.openLeaderboard':
+            result = await _handleGameCenterOpenLeaderboard();
+            break;
+          case 'gameCenter.submitScore':
+            result = await _handleGameCenterSubmitScore(payload);
+            break;
           default:
             throw Exception('Unknown command: $type');
         }
@@ -175,6 +187,39 @@ class BridgeService {
     debugPrint('[Bridge] Share: $url');
 
     return {'success': true};
+  }
+
+  /// Analytics 클릭 이벤트 (더미 구현)
+  Future<Map<String, dynamic>> _handleAnalyticsClick(
+    Map<String, dynamic> payload,
+  ) async {
+    final params = payload['params'] as Map<String, dynamic>?;
+    debugPrint('[Bridge] Analytics Click (not implemented): $params');
+    return {'success': true};
+  }
+
+  /// Analytics 노출 이벤트 (더미 구현)
+  Future<Map<String, dynamic>> _handleAnalyticsImpression(
+    Map<String, dynamic> payload,
+  ) async {
+    final params = payload['params'] as Map<String, dynamic>?;
+    debugPrint('[Bridge] Analytics Impression (not implemented): $params');
+    return {'success': true};
+  }
+
+  /// Game Center 리더보드 열기 (더미 구현)
+  Future<Map<String, dynamic>> _handleGameCenterOpenLeaderboard() async {
+    debugPrint('[Bridge] Game Center Open Leaderboard (not implemented)');
+    return {'success': false};
+  }
+
+  /// Game Center 점수 제출 (더미 구현)
+  Future<Map<String, dynamic>> _handleGameCenterSubmitScore(
+    Map<String, dynamic> payload,
+  ) async {
+    final score = payload['score'] as String?;
+    debugPrint('[Bridge] Game Center Submit Score (not implemented): $score');
+    return {'success': false, 'submitted': false};
   }
 
   /// 결과를 WebView로 전송 (CustomEvent)


### PR DESCRIPTION
## 개요
Flutter 브리지를 확장하여 Toss/Web과 동일한 기능 제공

## 주요 변경사항
1. **Bridge Service 확장**
   - Analytics (click/impression) 지원 추가
   - Game Center (leaderboard/score) 지원 추가
   - 총 10개 브리지 커맨드 지원

2. **Debug 모드 개선**
   - kDebugMode import 추가
   - Debug: localhost (10.0.2.2)
   - Release: Vercel production

3. **Android 배포 준비**
   - key.properties 설정 완료
   - Release signing 구성 완료

## 지원 기능
- ✅ 광고 (ad.request)
- ✅ Safe Area (safeArea.get)
- ✅ Storage (storage.set/get)
- ✅ 햅틱 (haptic.impact)
- ✅ 공유 (share.open)
- ✅ Analytics (analytics.click/impression) - 로그만
- ✅ Game Center (gameCenter.*) - 미구현

## 테스트 필요
- [ ] Web PR #186과 함께 통합 테스트
- [ ] Android release 빌드
- [ ] iOS release 빌드

## 관련 PR
- Web: #186 (tailbound/feat/flutter-bridge-wip)