### PR TITLE
fix: 앱 생명주기 → 게임 pause/resume + ad.preload

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,7 +77,7 @@ class WebViewPage extends StatefulWidget {
   State<WebViewPage> createState() => _WebViewPageState();
 }
 
-class _WebViewPageState extends State<WebViewPage> {
+class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
   late final WebViewController _controller;
   late final BridgeService _bridgeService;
   bool _isLoading = true;
@@ -86,7 +86,30 @@ class _WebViewPageState extends State<WebViewPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _initializeWebView();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  /// 앱 생명주기 변경 → WebView 게임 pause/resume
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.inactive:
+        _bridgeService.pauseGame();
+        break;
+      case AppLifecycleState.resumed:
+        _bridgeService.resumeGame();
+        break;
+      default:
+        break;
+    }
   }
 
   /// 앱 환경 정보를 WebView에 주입

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,6 +170,8 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
                 _errorMessage = null;
               });
             }
+            // JS 실행 전에 __APP_ENV__ 주입 (싱글톤 초기화보다 먼저)
+            _injectAppEnvironment();
           },
           onPageFinished: (String url) async {
             if (mounted) {
@@ -177,7 +179,7 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
                 _isLoading = false;
               });
 
-              // 앱 환경 정보 주입
+              // safe area는 layout 완료 후 정확한 값으로 재주입
               await _injectAppEnvironment();
             }
           },

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -42,6 +42,9 @@ class BridgeService {
           case 'storage.get':
             result = await _getStorage(payload);
             break;
+          case 'storage.remove':
+            result = await _removeStorage(payload);
+            break;
           case 'haptic.impact':
             result = await _triggerHaptic(payload);
             break;
@@ -188,6 +191,18 @@ class BridgeService {
     debugPrint('[Bridge] Storage get: $key = $value');
 
     return {'value': value};
+  }
+
+  /// 로컬 스토리지 삭제
+  Future<Map<String, dynamic>> _removeStorage(Map<String, dynamic> payload) async {
+    final key = payload['key'] as String;
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(key);
+
+    debugPrint('[Bridge] Storage remove: $key');
+
+    return {'success': true};
   }
 
   /// 햅틱 피드백

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -190,7 +190,7 @@ class BridgeService {
 
     debugPrint('[Bridge] Storage get: $key = $value');
 
-    return {'value': value};
+    return {'success': true, 'value': value};
   }
 
   /// 로컬 스토리지 삭제


### PR DESCRIPTION
## 요약
웹 게임(tailbound)의 WebView 안정성 강화를 위한 Flutter 네이티브 변경.

대응 PR: https://github.com/0xkkun/tailbound/pull/205

## 변경사항

### AppLifecycleState 연동
- `_WebViewPageState`에 `WidgetsBindingObserver` mixin 추가
- `paused`/`inactive` → `bridgeService.pauseGame()` → JS `__GAME_PAUSE__()`
- `resumed` → `bridgeService.resumeGame()` → JS `__GAME_RESUME__()`
- 홈 이동, 앱 전환, 전화 수신 시 게임 자동 정지

### ad.preload 핸들러
- `BridgeService`에 `ad.preload` 커맨드 추가
- 웹에서 `bridge.preloadAd('revival')` 호출 시 `AdManager.preloadAd()` 실행
- 게임 세션 시작 시 revival/bundle 광고 미리 로드

### pauseGame/resumeGame public
- 기존 `_pauseGame`/`_resumeGame` → `pauseGame`/`resumeGame`
- 광고 + 앱 생명주기 양쪽에서 호출 가능
