### PR TITLE
feat: 로컬 푸시 알림 시스템 — 리텐션 루프

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,6 +20,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -60,6 +61,10 @@ android {
             }
         }
     }
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <!-- AdMob requires Advertising ID -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    <!-- Local notifications -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
     <application
         android:label="설화"
         android:name="${applicationName}"
@@ -31,6 +36,16 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Scheduled notification on boot -->
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"/>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <!-- Local notifications -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <application

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import flutter_local_notifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,6 +8,15 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // flutter_local_notifications iOS setup
+    FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { (registry) in
+      GeneratedPluginRegistrant.register(with: registry)
+    }
+
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as UNUserNotificationCenterDelegate
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -69,5 +69,10 @@
 	<string>ca-app-pub-2202284171552842~8016444869</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -71,7 +71,6 @@
 	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 </dict>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,5 +5,11 @@
   "exitDialogCancel": "Continue",
   "exitDialogConfirm": "Quit",
   "errorLoadingPage": "Failed to load page",
-  "errorRetry": "Retry"
+  "errorRetry": "Retry",
+  "notificationReturnTitle": "The Shaman awaits your return",
+  "notificationReturnBody": "The Demon Gate is opening again. Come back and hold the line!",
+  "notificationDailyTitle": "Today's challenge awaits",
+  "notificationDailyBody": "The world of Seolhwa is calling you.",
+  "notificationInactiveTitle": "Death's Envoy is calling",
+  "notificationInactiveBody": "The Demon Gate grew stronger while you were away. Time to return!"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -23,5 +23,29 @@
   "errorRetry": "다시 시도",
   "@errorRetry": {
     "description": "재시도 버튼"
+  },
+  "notificationReturnTitle": "무녀가 기다리고 있어요",
+  "@notificationReturnTitle": {
+    "description": "복귀 알림 제목"
+  },
+  "notificationReturnBody": "귀문이 다시 열리고 있어요. 돌아와서 막아주세요!",
+  "@notificationReturnBody": {
+    "description": "복귀 알림 본문"
+  },
+  "notificationDailyTitle": "오늘의 도전이 기다립니다",
+  "@notificationDailyTitle": {
+    "description": "데일리 알림 제목"
+  },
+  "notificationDailyBody": "설화 속 세계가 당신을 부르고 있어요.",
+  "@notificationDailyBody": {
+    "description": "데일리 알림 본문"
+  },
+  "notificationInactiveTitle": "저승사자가 부르고 있어요",
+  "@notificationInactiveTitle": {
+    "description": "장기이탈 알림 제목"
+  },
+  "notificationInactiveBody": "오래 비웠더니 귀문이 더 강해졌어요. 돌아올 때가 됐어요!",
+  "@notificationInactiveBody": {
+    "description": "장기이탈 알림 본문"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -133,6 +133,42 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'다시 시도'**
   String get errorRetry;
+
+  /// 복귀 알림 제목
+  ///
+  /// In ko, this message translates to:
+  /// **'무녀가 기다리고 있어요'**
+  String get notificationReturnTitle;
+
+  /// 복귀 알림 본문
+  ///
+  /// In ko, this message translates to:
+  /// **'귀문이 다시 열리고 있어요. 돌아와서 막아주세요!'**
+  String get notificationReturnBody;
+
+  /// 데일리 알림 제목
+  ///
+  /// In ko, this message translates to:
+  /// **'오늘의 도전이 기다립니다'**
+  String get notificationDailyTitle;
+
+  /// 데일리 알림 본문
+  ///
+  /// In ko, this message translates to:
+  /// **'설화 속 세계가 당신을 부르고 있어요.'**
+  String get notificationDailyBody;
+
+  /// 장기이탈 알림 제목
+  ///
+  /// In ko, this message translates to:
+  /// **'저승사자가 부르고 있어요'**
+  String get notificationInactiveTitle;
+
+  /// 장기이탈 알림 본문
+  ///
+  /// In ko, this message translates to:
+  /// **'오래 비웠더니 귀문이 더 강해졌어요. 돌아올 때가 됐어요!'**
+  String get notificationInactiveBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -25,4 +25,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get errorRetry => 'Retry';
+
+  @override
+  String get notificationReturnTitle => 'The Shaman awaits your return';
+
+  @override
+  String get notificationReturnBody =>
+      'The Demon Gate is opening again. Come back and hold the line!';
+
+  @override
+  String get notificationDailyTitle => 'Today\'s challenge awaits';
+
+  @override
+  String get notificationDailyBody => 'The world of Seolhwa is calling you.';
+
+  @override
+  String get notificationInactiveTitle => 'Death\'s Envoy is calling';
+
+  @override
+  String get notificationInactiveBody =>
+      'The Demon Gate grew stronger while you were away. Time to return!';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -25,4 +25,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get errorRetry => '다시 시도';
+
+  @override
+  String get notificationReturnTitle => '무녀가 기다리고 있어요';
+
+  @override
+  String get notificationReturnBody => '귀문이 다시 열리고 있어요. 돌아와서 막아주세요!';
+
+  @override
+  String get notificationDailyTitle => '오늘의 도전이 기다립니다';
+
+  @override
+  String get notificationDailyBody => '설화 속 세계가 당신을 부르고 있어요.';
+
+  @override
+  String get notificationInactiveTitle => '저승사자가 부르고 있어요';
+
+  @override
+  String get notificationInactiveBody => '오래 비웠더니 귀문이 더 강해졌어요. 돌아올 때가 됐어요!';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -103,6 +103,23 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _initializeWebView();
+    // 데일리 알림은 첫 프레임 후 context 있을 때 스케줄
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scheduleDailyNotification();
+    });
+  }
+
+  /// 데일리 알림 기본 스케줄 (매일 20시)
+  void _scheduleDailyNotification() {
+    final l10n = AppLocalizations.of(context);
+    if (l10n != null) {
+      NotificationService.instance.scheduleDailyReminder(
+        hour: 20,
+        minute: 0,
+        title: l10n.notificationDailyTitle,
+        body: l10n.notificationDailyBody,
+      );
+    }
   }
 
   @override

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -6,6 +6,7 @@ import 'package:webview_flutter/webview_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../ad_manager.dart';
+import 'notification_service.dart';
 
 /// Flutter Bridge Service
 /// 웹 게임과 네이티브 기능 간의 통합 브리지
@@ -62,6 +63,12 @@ class BridgeService {
             break;
           case 'gameCenter.submitScore':
             result = await _handleGameCenterSubmitScore(payload);
+            break;
+          case 'notification.scheduleDailyReminder':
+            result = await _handleScheduleDailyReminder(payload);
+            break;
+          case 'notification.cancelAll':
+            result = await _handleCancelAllNotifications();
             break;
           default:
             throw Exception('Unknown command: $type');
@@ -270,6 +277,31 @@ class BridgeService {
     final score = payload['score'] as String?;
     debugPrint('[Bridge] Game Center Submit Score (not implemented): $score');
     return {'success': false, 'submitted': false};
+  }
+
+  /// 데일리 알림 스케줄
+  Future<Map<String, dynamic>> _handleScheduleDailyReminder(
+    Map<String, dynamic> payload,
+  ) async {
+    final hour = payload['hour'] as int? ?? 20;
+    final minute = payload['minute'] as int? ?? 0;
+    final title = payload['title'] as String? ?? '오늘의 도전이 기다립니다';
+    final body = payload['body'] as String? ?? '설화 속 세계가 당신을 부르고 있어요.';
+
+    await NotificationService.instance.scheduleDailyReminder(
+      hour: hour,
+      minute: minute,
+      title: title,
+      body: body,
+    );
+
+    return {'success': true};
+  }
+
+  /// 모든 알림 취소
+  Future<Map<String, dynamic>> _handleCancelAllNotifications() async {
+    await NotificationService.instance.cancelAll();
+    return {'success': true};
   }
 
   /// 게임 pause (광고 표시 전 / 앱 백그라운드 전환 시)

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,257 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest_all.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+/// 로컬 푸시 알림 서비스
+/// 리텐션 알림(복귀, 데일리, 장기이탈)을 스케줄링합니다.
+class NotificationService {
+  NotificationService._();
+  static final NotificationService instance = NotificationService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _initialized = false;
+
+  // 알림 ID 상수
+  static const int returnReminderId = 1001;
+  static const int dailyReminderId = 1002;
+  static const int inactiveReminderId = 1003;
+
+  // 야간 금지 시간 (KST)
+  static const int quietHourStart = 23; // 23:00
+  static const int quietHourEnd = 8; // 08:00
+
+  /// 알림 채널 (Android)
+  static const String _channelId = 'tailbound_reminders';
+  static const String _channelName = '설화 알림';
+  static const String _channelDescription = '게임 리마인더 알림';
+
+  /// 초기화
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    // timezone 초기화
+    tz.initializeTimeZones();
+    tz.setLocalLocation(tz.getLocation('Asia/Seoul'));
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+
+    const settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _plugin.initialize(
+      settings,
+      onDidReceiveNotificationResponse: _onNotificationTapped,
+    );
+
+    _initialized = true;
+    debugPrint('[NotificationService] Initialized');
+  }
+
+  /// 알림 권한 요청
+  Future<bool> requestPermission() async {
+    if (Platform.isIOS) {
+      final result = await _plugin
+          .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(alert: true, badge: true, sound: true);
+      debugPrint('[NotificationService] iOS permission: $result');
+      return result ?? false;
+    }
+
+    if (Platform.isAndroid) {
+      final android = _plugin.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+      final result = await android?.requestNotificationsPermission();
+      debugPrint('[NotificationService] Android permission: $result');
+      return result ?? false;
+    }
+
+    return false;
+  }
+
+  /// 복귀 알림 스케줄 (N시간 후)
+  Future<void> scheduleReturnReminder({
+    int hours = 4,
+    required String title,
+    required String body,
+  }) async {
+    final scheduledTime = _adjustForQuietHours(
+      tz.TZDateTime.now(tz.local).add(Duration(hours: hours)),
+    );
+
+    await _scheduleNotification(
+      id: returnReminderId,
+      title: title,
+      body: body,
+      scheduledTime: scheduledTime,
+    );
+
+    debugPrint('[NotificationService] Return reminder scheduled: $scheduledTime');
+  }
+
+  /// 데일리 알림 스케줄 (매일 지정 시간)
+  Future<void> scheduleDailyReminder({
+    int hour = 20,
+    int minute = 0,
+    required String title,
+    required String body,
+  }) async {
+    // 야간 금지 시간대면 08시로 조정
+    int adjustedHour = hour;
+    if (_isQuietHour(hour)) {
+      adjustedHour = quietHourEnd;
+      debugPrint('[NotificationService] Daily reminder adjusted to $adjustedHour:00 (quiet hours)');
+    }
+
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduledTime = tz.TZDateTime(
+      tz.local,
+      now.year,
+      now.month,
+      now.day,
+      adjustedHour,
+      minute,
+    );
+
+    // 이미 지난 시간이면 내일로
+    if (scheduledTime.isBefore(now)) {
+      scheduledTime = scheduledTime.add(const Duration(days: 1));
+    }
+
+    await _plugin.zonedSchedule(
+      dailyReminderId,
+      title,
+      body,
+      scheduledTime,
+      _notificationDetails(),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+
+    debugPrint('[NotificationService] Daily reminder scheduled: $adjustedHour:${minute.toString().padLeft(2, '0')}');
+  }
+
+  /// 장기 이탈 알림 스케줄 (24시간 후)
+  Future<void> scheduleInactiveReminder({
+    int hours = 24,
+    required String title,
+    required String body,
+  }) async {
+    final scheduledTime = _adjustForQuietHours(
+      tz.TZDateTime.now(tz.local).add(Duration(hours: hours)),
+    );
+
+    await _scheduleNotification(
+      id: inactiveReminderId,
+      title: title,
+      body: body,
+      scheduledTime: scheduledTime,
+    );
+
+    debugPrint('[NotificationService] Inactive reminder scheduled: $scheduledTime');
+  }
+
+  /// 복귀 알림 취소 (앱 복귀 시)
+  Future<void> cancelReturnReminder() async {
+    await _plugin.cancel(returnReminderId);
+    debugPrint('[NotificationService] Return reminder cancelled');
+  }
+
+  /// 장기 이탈 알림 취소
+  Future<void> cancelInactiveReminder() async {
+    await _plugin.cancel(inactiveReminderId);
+    debugPrint('[NotificationService] Inactive reminder cancelled');
+  }
+
+  /// 모든 알림 취소
+  Future<void> cancelAll() async {
+    await _plugin.cancelAll();
+    debugPrint('[NotificationService] All notifications cancelled');
+  }
+
+  /// 특정 ID 알림 취소
+  Future<void> cancelById(int id) async {
+    await _plugin.cancel(id);
+  }
+
+  // === Private ===
+
+  /// 알림 탭 콜백
+  void _onNotificationTapped(NotificationResponse response) {
+    debugPrint('[NotificationService] Notification tapped: ${response.id}');
+    // 앱이 열리면서 자연스럽게 게임으로 이동
+  }
+
+  /// 야간 금지 시간대 체크
+  bool _isQuietHour(int hour) {
+    return hour >= quietHourStart || hour < quietHourEnd;
+  }
+
+  /// 야간 금지 시간대면 다음날 08시로 조정
+  tz.TZDateTime _adjustForQuietHours(tz.TZDateTime dateTime) {
+    if (_isQuietHour(dateTime.hour)) {
+      // 다음날 08시로 밀기
+      var adjusted = tz.TZDateTime(
+        tz.local,
+        dateTime.year,
+        dateTime.month,
+        dateTime.day,
+        quietHourEnd,
+        0,
+      );
+      // 현재 시간이 자정 이전이면 내일로
+      if (dateTime.hour >= quietHourStart) {
+        adjusted = adjusted.add(const Duration(days: 1));
+      }
+      return adjusted;
+    }
+    return dateTime;
+  }
+
+  /// 알림 스케줄 (공통)
+  Future<void> _scheduleNotification({
+    required int id,
+    required String title,
+    required String body,
+    required tz.TZDateTime scheduledTime,
+  }) async {
+    await _plugin.zonedSchedule(
+      id,
+      title,
+      body,
+      scheduledTime,
+      _notificationDetails(),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+    );
+  }
+
+  /// 알림 디테일 (Android 채널 + iOS 설정)
+  NotificationDetails _notificationDetails() {
+    return const NotificationDetails(
+      android: AndroidNotificationDetails(
+        _channelId,
+        _channelName,
+        channelDescription: _channelDescription,
+        importance: Importance.high,
+        priority: Priority.high,
+        icon: '@mipmap/ic_launcher',
+      ),
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -214,6 +222,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -253,6 +293,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
@@ -586,6 +642,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   google_mobile_ads: ^6.0.0
   share_plus: ^10.1.4
   shared_preferences: ^2.3.5
+  flutter_local_notifications: ^19.0.0
+  timezone: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 변경 사항

### 로컬 푸시 알림으로 유저 복귀 유도

토스 스마트 발송 폐지 이후 리텐션 드라이버 확보를 위한 네이티브 로컬 알림 시스템.

### 알림 종류
- **복귀 알림** (4시간 후): "무녀가 기다리고 있어요"
- **데일리 알림** (매일 20시): "오늘의 도전이 기다립니다"  
- **장기 이탈** (24시간 후): "저승사자가 부르고 있어요"

### 정책
- 🌙 야간 발송 금지 (23:00~08:00 KST) — 한국 정보통신법 준수
- 📱 iOS/Android 권한 요청 처리
- 🔄 앱 lifecycle 자동 연동 (백그라운드→알림 예약, 포그라운드→취소)
- 🌐 웹뷰 브릿지 커맨드 지원 (게임에서 알림 제어 가능)
- 🗣️ i18n (한/영)

### 기술
- `flutter_local_notifications` + `timezone` 패키지
- Android: desugaring, SCHEDULE_EXACT_ALARM, POST_NOTIFICATIONS
- iOS: AppDelegate 델리게이트, UIBackgroundModes

### 변경 파일
- 14 files, +519 lines