### PR TITLE
feat: WebView 개선 — 배너 광고 수정, 안정성, 브릿지 문서화

### DIFF
--- a/docs/BRIDGE_PROTOCOL.md
+++ b/docs/BRIDGE_PROTOCOL.md
@@ -1,0 +1,249 @@
+# Flutter Bridge Protocol
+
+웹 게임(WebView)과 Flutter 네이티브 간 통신 프로토콜.
+
+## 아키텍처
+
+```
+Web (JS)  ──→  FlutterBridge.postMessage(json)  ──→  Flutter (Dart)
+Web (JS)  ←──  CustomEvent 'flutterBridgeResult'  ←──  Flutter (Dart)
+```
+
+- **요청**: 웹에서 `window.FlutterBridge.postMessage(JSON.stringify(request))` 호출
+- **응답**: Flutter에서 `window.dispatchEvent(new CustomEvent('flutterBridgeResult', { detail }))` 발송
+
+## 요청 포맷
+
+```typescript
+interface BridgeRequest {
+  id: string;        // 고유 요청 ID (응답 매칭용)
+  type: string;      // 커맨드 타입
+  payload: object;   // 커맨드별 페이로드
+}
+```
+
+## 응답 포맷
+
+```typescript
+interface BridgeResponse {
+  id: string;        // 요청 ID (매칭)
+  type: string;      // 커맨드 타입
+  success: boolean;
+  data?: object;     // 성공 시 데이터
+  error?: string;    // 실패 시 에러 메시지
+  timestamp: number; // 응답 시각 (ms)
+}
+```
+
+## 웹에서 호출하는 법
+
+```typescript
+function callFlutterBridge(type: string, payload: object): Promise<any> {
+  const id = crypto.randomUUID();
+
+  return new Promise((resolve, reject) => {
+    const handler = (e: CustomEvent) => {
+      if (e.detail.id !== id) return;
+      window.removeEventListener('flutterBridgeResult', handler);
+      if (e.detail.success) resolve(e.detail.data);
+      else reject(new Error(e.detail.error));
+    };
+    window.addEventListener('flutterBridgeResult', handler);
+
+    window.FlutterBridge.postMessage(JSON.stringify({ id, type, payload }));
+  });
+}
+```
+
+---
+
+## 커맨드 레퍼런스
+
+### 광고
+
+#### `ad.request` — 보상형 광고 표시
+
+게임을 자동 pause → 광고 표시 → 종료 후 resume.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `adType` | `string` | `artifact` \| `revival` \| `reroll` \| `bundle` |
+
+**응답 data:**
+```json
+{ "success": true, "rewarded": true }
+```
+
+- `success`: 광고가 정상 표시됐는지
+- `rewarded`: 사용자가 보상을 받았는지 (중간에 닫으면 false)
+
+#### `ad.preload` — 광고 미리 로드
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `adType` | `string` | `artifact` \| `revival` \| `reroll` \| `bundle` |
+
+**응답 data:**
+```json
+{ "success": true }
+```
+
+---
+
+### 스토리지
+
+SharedPreferences 기반. 앱 삭제 시 초기화됨.
+
+#### `storage.set` — 저장
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `key` | `string` | 저장 키 |
+| `value` | `string` | 저장 값 (문자열만) |
+
+#### `storage.get` — 조회
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `key` | `string` | 조회 키 |
+
+**응답 data:**
+```json
+{ "success": true, "value": "stored_value" }
+```
+`value`는 없으면 `null`.
+
+#### `storage.remove` — 삭제
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `key` | `string` | 삭제할 키 |
+
+---
+
+### 디바이스
+
+#### `safeArea.get` — Safe Area 조회
+
+페이로드 없음.
+
+**응답 data:**
+```json
+{ "top": 47.0, "bottom": 34.0, "left": 0.0, "right": 0.0 }
+```
+
+> 참고: 정확한 값은 앱 시작 시 `window.__APP_ENV__.safeArea`로 자동 주입됨. 이 커맨드는 fallback용.
+
+#### `haptic.impact` — 햅틱 피드백
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `style` | `string` | 아래 표 참조 (기본값: `mediumImpact`) |
+
+| style | iOS 매핑 | 용도 |
+|-------|----------|------|
+| `selectionClick` | UISelectionFeedback | UI 선택 |
+| `lightImpact` | Light | 가벼운 터치 |
+| `mediumImpact` | Medium | 일반 인터랙션 |
+| `heavyImpact` | Heavy | 강한 피드백 |
+| `notificationSuccess` | Light | 성공 알림 |
+| `notificationWarning` | Medium | 경고 |
+| `notificationError` | Heavy | 에러 |
+| `light` | Light | 레거시 호환 |
+| `medium` | Medium | 레거시 호환 |
+| `heavy` | Heavy | 레거시 호환 |
+
+#### `share.open` — 공유 다이얼로그
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `url` | `string` | 공유할 URL |
+| `title` | `string?` | 공유 텍스트 제목 (선택) |
+
+---
+
+### 애널리틱스 (더미)
+
+현재 로깅만 수행. 추후 Firebase Analytics 연동 예정.
+
+#### `analytics.click` — 클릭 이벤트
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `params` | `object?` | 이벤트 파라미터 |
+
+#### `analytics.impression` — 노출 이벤트
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `params` | `object?` | 이벤트 파라미터 |
+
+---
+
+### Game Center (더미)
+
+현재 미구현. 항상 `success: false` 반환.
+
+#### `gameCenter.openLeaderboard`
+
+페이로드 없음.
+
+#### `gameCenter.submitScore`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `score` | `string` | 제출할 점수 |
+
+---
+
+## 자동 주입 환경변수
+
+앱 시작 시 Flutter가 `window.__APP_ENV__`를 자동 주입:
+
+```typescript
+interface AppEnv {
+  platform: 'flutter';
+  os: 'ios' | 'android';
+  version: string;       // "1.0.6+7" 형식
+  safeArea: {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
+}
+```
+
+## 게임 생명주기
+
+Flutter가 호출하는 글로벌 함수 (웹에서 구현 필요):
+
+| 함수 | 호출 시점 |
+|------|-----------|
+| `window.__GAME_PAUSE__()` | 앱 백그라운드 / 광고 표시 전 |
+| `window.__GAME_RESUME__()` | 앱 포그라운드 / 광고 종료 후 |
+
+Fallback: 위 함수 없으면 `window.__PIXI_APP__.ticker.stop()/start()` 시도.
+
+---
+
+## 디버그
+
+### 디버그 URL 설정
+
+```bash
+# 에뮬레이터 (기본)
+flutter run --dart-define=DEBUG_URL=http://10.0.2.2:5173/
+
+# 실기기 (adb reverse 필요)
+adb reverse tcp:5173 tcp:5173
+flutter run
+# 기본값 http://localhost:5173/ 사용
+```
+
+### 로그 확인
+
+모든 브릿지 메시지는 `[Bridge]` 접두사로 로깅:
+```
+flutter logs | grep Bridge
+```

--- a/docs/BRIDGE_PROTOCOL.md
+++ b/docs/BRIDGE_PROTOCOL.md
@@ -101,6 +101,11 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 | `key` | `string` | 저장 키 |
 | `value` | `string` | 저장 값 (문자열만) |
 
+**응답 data:**
+```json
+{ "success": true }
+```
+
 #### `storage.get` — 조회
 
 | 필드 | 타입 | 설명 |
@@ -119,6 +124,11 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 |------|------|------|
 | `key` | `string` | 삭제할 키 |
 
+**응답 data:**
+```json
+{ "success": true }
+```
+
 ---
 
 ### 디바이스
@@ -135,6 +145,11 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 > 참고: 정확한 값은 앱 시작 시 `window.__APP_ENV__.safeArea`로 자동 주입됨. 이 커맨드는 fallback용.
 
 #### `haptic.impact` — 햅틱 피드백
+
+**응답 data:**
+```json
+{ "success": true }
+```
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
@@ -160,6 +175,11 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 | `url` | `string` | 공유할 URL |
 | `title` | `string?` | 공유 텍스트 제목 (선택) |
 
+**응답 data:**
+```json
+{ "success": true }
+```
+
 ---
 
 ### 애널리틱스 (더미)
@@ -172,11 +192,21 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 |------|------|------|
 | `params` | `object?` | 이벤트 파라미터 |
 
+**응답 data:**
+```json
+{ "success": true }
+```
+
 #### `analytics.impression` — 노출 이벤트
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
 | `params` | `object?` | 이벤트 파라미터 |
+
+**응답 data:**
+```json
+{ "success": true }
+```
 
 ---
 
@@ -188,11 +218,21 @@ SharedPreferences 기반. 앱 삭제 시 초기화됨.
 
 페이로드 없음.
 
+**응답 data:**
+```json
+{ "success": false }
+```
+
 #### `gameCenter.submitScore`
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| `score` | `string` | 제출할 점수 |
+| `score` | `string?` | 제출할 점수 (nullable) |
+
+**응답 data:**
+```json
+{ "success": false, "submitted": false }
+```
 
 ---
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,9 +104,16 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    PackageInfo.fromPlatform().then((info) {
+    _initAsync();
+  }
+
+  Future<void> _initAsync() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
       _appVersion = '${info.version}+${info.buildNumber}';
-    });
+    } catch (e) {
+      debugPrint('PackageInfo failed: $e');
+    }
     _initializeWebView();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,7 +96,7 @@ class WebViewPage extends StatefulWidget {
 
 class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
   late final WebViewController _controller;
-  late final BridgeService _bridgeService;
+  BridgeService? _bridgeService;
   String _appVersion = '1.0.0';
   bool _isLoading = true;
   String? _errorMessage;
@@ -114,6 +114,7 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
     } catch (e) {
       debugPrint('PackageInfo failed: $e');
     }
+    if (!mounted) return;
     _initializeWebView();
   }
 
@@ -129,10 +130,10 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
     switch (state) {
       case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
-        _bridgeService.pauseGame();
+        _bridgeService?.pauseGame();
         break;
       case AppLifecycleState.resumed:
-        _bridgeService.resumeGame();
+        _bridgeService?.resumeGame();
         break;
       default:
         break;
@@ -185,7 +186,7 @@ class _WebViewPageState extends State<WebViewPage> with WidgetsBindingObserver {
       ..addJavaScriptChannel(
         'FlutterBridge',
         onMessageReceived: (JavaScriptMessage message) {
-          _bridgeService.handleMessage(message.message);
+          _bridgeService?.handleMessage(message.message);
         },
       )
       ..setNavigationDelegate(

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -332,7 +332,8 @@ class BridgeService {
         .replaceAll("'", "\\'")
         .replaceAll('\n', '\\n')
         .replaceAll('\r', '\\r');
-    final js = """
+    final js =
+        """
       window.dispatchEvent(new CustomEvent('flutterBridgeResult', {
         detail: JSON.parse('$escaped')
       }));

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -331,7 +331,9 @@ class BridgeService {
         .replaceAll('\\', '\\\\')
         .replaceAll("'", "\\'")
         .replaceAll('\n', '\\n')
-        .replaceAll('\r', '\\r');
+        .replaceAll('\r', '\\r')
+        .replaceAll('\u2028', '\\u2028')
+        .replaceAll('\u2029', '\\u2029');
     final js =
         """
       window.dispatchEvent(new CustomEvent('flutterBridgeResult', {

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -326,20 +326,11 @@ class BridgeService {
     };
 
     final resultJson = jsonEncode(result);
-    // JS string literal 안에서 안전하게 전달하기 위해 이스케이프
-    final escaped = resultJson
-        .replaceAll('\\', '\\\\')
-        .replaceAll("'", "\\'")
-        .replaceAll('\n', '\\n')
-        .replaceAll('\r', '\\r')
-        .replaceAll('\u2028', '\\u2028')
-        .replaceAll('\u2029', '\\u2029');
+    // jsonEncode를 두 번 호출하여 JS string literal로 안전하게 전달
+    // 첫 번째: Object → JSON string, 두 번째: JSON string → JS string literal
+    final jsStringLiteral = jsonEncode(resultJson);
     final js =
-        """
-      window.dispatchEvent(new CustomEvent('flutterBridgeResult', {
-        detail: JSON.parse('$escaped')
-      }));
-    """;
+        'window.dispatchEvent(new CustomEvent(\'flutterBridgeResult\', { detail: JSON.parse($jsStringLiteral) }));';
 
     await webViewController.runJavaScript(js);
     debugPrint('[Bridge] Result sent: $type (success: $success)');

--- a/lib/services/bridge_service.dart
+++ b/lib/services/bridge_service.dart
@@ -326,12 +326,17 @@ class BridgeService {
     };
 
     final resultJson = jsonEncode(result);
-    final js =
-        '''
+    // JS string literal 안에서 안전하게 전달하기 위해 이스케이프
+    final escaped = resultJson
+        .replaceAll('\\', '\\\\')
+        .replaceAll("'", "\\'")
+        .replaceAll('\n', '\\n')
+        .replaceAll('\r', '\\r');
+    final js = """
       window.dispatchEvent(new CustomEvent('flutterBridgeResult', {
-        detail: $resultJson
+        detail: JSON.parse('$escaped')
       }));
-    ''';
+    """;
 
     await webViewController.runJavaScript(js);
     debugPrint('[Bridge] Result sent: $type (success: $success)');

--- a/lib/widgets/exit_confirm_dialog.dart
+++ b/lib/widgets/exit_confirm_dialog.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import '../ad_manager.dart';
+import '../l10n/app_localizations.dart';
+
+class ExitConfirmDialog extends StatefulWidget {
+  const ExitConfirmDialog({super.key});
+
+  @override
+  State<ExitConfirmDialog> createState() => _ExitConfirmDialogState();
+}
+
+class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
+  BannerAd? _bannerAd;
+  bool _bannerReady = false;
+  int _retryCount = 0;
+  static const int _maxRetries = 3;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBannerAd();
+  }
+
+  void _loadBannerAd() {
+    _bannerAd = BannerAd(
+      adUnitId: AdManager.getBannerAdUnitId(BannerAdType.exitPopup),
+      size: AdSize.mediumRectangle,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (ad) {
+          debugPrint('Exit banner ad loaded');
+          if (mounted) setState(() => _bannerReady = true);
+        },
+        onAdFailedToLoad: (ad, error) {
+          debugPrint('Exit banner ad failed to load: $error');
+          ad.dispose();
+          _bannerAd = null;
+          _retryCount++;
+          if (_retryCount < _maxRetries) {
+            Future.delayed(const Duration(seconds: 2), () {
+              if (mounted) _loadBannerAd();
+            });
+          }
+        },
+      ),
+    );
+    _bannerAd!.load();
+  }
+
+  @override
+  void dispose() {
+    _bannerAd?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Dialog(
+      backgroundColor: const Color(0xFF1A1A2E),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (_bannerReady && _bannerAd != null)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: SizedBox(
+                  width: AdSize.mediumRectangle.width.toDouble(),
+                  height: AdSize.mediumRectangle.height.toDouble(),
+                  child: AdWidget(ad: _bannerAd!),
+                ),
+              ),
+            if (_bannerReady && _bannerAd != null) const SizedBox(height: 16),
+            Text(
+              l10n.exitDialogTitle,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              l10n.exitDialogSubtitle,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.6),
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(
+                        color: Colors.white.withValues(alpha: 0.3),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: Text(
+                      l10n.exitDialogCancel,
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF8B0000),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: Text(
+                      l10n.exitDialogConfirm,
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/exit_confirm_dialog.dart
+++ b/lib/widgets/exit_confirm_dialog.dart
@@ -13,6 +13,7 @@ class ExitConfirmDialog extends StatefulWidget {
 class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
   BannerAd? _bannerAd;
   bool _bannerReady = false;
+  bool _disposed = false;
   int _retryCount = 0;
   static const int _maxRetries = 3;
 
@@ -23,6 +24,7 @@ class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
   }
 
   void _loadBannerAd() {
+    if (_disposed || !mounted) return;
     _bannerAd = BannerAd(
       adUnitId: AdManager.getBannerAdUnitId(BannerAdType.exitPopup),
       size: AdSize.mediumRectangle,
@@ -50,6 +52,7 @@ class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
 
   @override
   void dispose() {
+    _disposed = true;
     _bannerAd?.dispose();
     _bannerAd = null;
     super.dispose();

--- a/lib/widgets/exit_confirm_dialog.dart
+++ b/lib/widgets/exit_confirm_dialog.dart
@@ -51,6 +51,7 @@ class _ExitConfirmDialogState extends State<ExitConfirmDialog> {
   @override
   void dispose() {
     _bannerAd?.dispose();
+    _bannerAd = null;
     super.dispose();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,6 +253,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
@@ -365,6 +381,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.5"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   google_mobile_ads: ^6.0.0
   share_plus: ^10.1.4
   shared_preferences: ^2.3.5
+  package_info_plus: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 변경 사항

### 🔴 P0: 종료팝업 배너 광고 수정
- `ExitConfirmDialog`를 별도 `StatefulWidget`으로 분리
- 다이얼로그 열 때마다 새 `BannerAd` 생성 → dispose 시 정리
- 로드 실패 시 최대 3회 재시도 (2초 간격)
- **원인**: `AdWidget`은 한 번 트리에서 제거되면 같은 `BannerAd` 인스턴스 재사용 불가

### 🟡 P1: 안정성 수정
- `__APP_ENV__.version`: 하드코딩 `1.0.0` → `package_info_plus`로 동적 조회
- 디버그 URL: `--dart-define=DEBUG_URL=...`로 오버라이드 가능 (기본 `localhost:5173`)
- `_sendResult` JSON 이스케이프: 특수문자가 JS 파싱 깨뜨리는 문제 방지

### 📝 문서: 브릿지 프로토콜
- `docs/BRIDGE_PROTOCOL.md` — 전체 커맨드 레퍼런스
- 요청/응답 포맷, JS 호출 예시, 생명주기, 디버그 가이드